### PR TITLE
added configuration for the silence form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added configuration for the silence form to reduce the amount of default values.
+
 ## [0.1.6] - 2020-12-22
 
 ## [0.1.5] - 2020-12-21

--- a/helm/karma-app/values.yaml
+++ b/helm/karma-app/values.yaml
@@ -140,6 +140,38 @@ configMap:
     log:
       config: false
       level: info
+    silenceForm:
+      strip:
+        labels:
+          - area
+          - cancel_if_cluster_status_creating
+          - cancel_if_cluster_status_deleting
+          - cancel_if_cluster_status_updating
+          - cancel_if_cluster_with_notready_nodepools
+          - cancel_if_outside_working_hours
+          - condition
+          - customer
+          - exported_cluster_id
+          - exported_namespace
+          - exported_node
+          - installation
+          - instance
+          - ip
+          - job
+          - job_name
+          - node
+          - phase
+          - pipeline
+          - pod
+          - pod_name
+          - pod_phase
+          - pod_ready
+          - provider
+          - region
+          - severity
+          - status
+          - team
+          - topic
     ui:
       refresh: 30s
       hideFiltersWhenIdle: true


### PR DESCRIPTION
I noticed that when silencing an alert from karma, the default silence will contain all labels and values taken from that alert. Some of them refer to specific pods or instances and will be different next time the issue occurs and others are just redundant and not needed to select an alert. This adds a configuration which strips some of the common labels.