### PR TITLE
Display only stable installations by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Display only stable installations by default.
+
 ## [0.2.0] - 2021-01-12
 
 ### Added

--- a/helm/karma-app/values.yaml
+++ b/helm/karma-app/values.yaml
@@ -98,6 +98,7 @@ configMap:
         - team=firecracker
         - alertname!~Inhibition
         - alertname!~Heartbeat
+        - pipeline=stable
     grid:
       sorting:
         order: label


### PR DESCRIPTION
We noticed in the last alert session that it would be better to filter out testing installations in the alert dashboard by default.